### PR TITLE
fix for Debian compabilities and fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Because librealtime is a header only library, you **Do NOT** need to build.
 ## 4.Dependency
 
 - librealtime can use **ONLY** linux.
-	This library was tested on **Ubuntu** and **Linux Mint**.
+	This library was tested on **Ubuntu**, **Linux Mint**, **Debian**.
 - librealtime require C++11 or more greater.
 
 

--- a/example/testRealtimeThread.cpp
+++ b/example/testRealtimeThread.cpp
@@ -12,20 +12,20 @@
 
 using namespace std;
 
-//std::vector<std::chrono::high_resolution_clock::time_point> vec(2000);
-std::array<std::chrono::high_resolution_clock::time_point, 1000> time_array;
+const size_t size = 1000;
+std::array<std::chrono::high_resolution_clock::time_point, size> time_array;
 int i = 0;
 
 void test()
 {
 	auto point = std::chrono::high_resolution_clock::now();
-	time_array[i] = point;
+	if(i<size) time_array[i] = point;
 	i++;
 }
 
 int main(int argc, char const* argv[])
 {
-	RealtimeThread th(1000, test);
+	RealtimeThread th(size, test);
 	th.start(true);
 	sleep(1);
 	th.join();

--- a/librealtime/RealtimeThread.hpp
+++ b/librealtime/RealtimeThread.hpp
@@ -12,6 +12,11 @@
 #include <sys/syscall.h>
 #include <sys/types.h>
 
+#ifndef SCHED_DEADLINE
+  #define REQ_NICE
+  #include <linux/sched.h>
+#endif
+
 /**
  * @brief Scheduling attributer. It is used to set configuration of realtime
  */
@@ -24,7 +29,9 @@ struct sched_attr
 
 	//SCHED_FIFO, SCHED_RR
 	uint32_t sched_priority;
-
+#ifdef REQ_NICE
+    int32_t sched_nice;
+#endif
 	//SCHED_DEADLINE
 	uint64_t sched_runtime;
 	uint64_t sched_deadline;


### PR DESCRIPTION
1. Fix for compatibility with Debian (added inclusion of SCHED_DEADLINE definition and addition of sched_attr field to structure)
2. Example - the size of the array is set in 1 variable, the check index of the array is added